### PR TITLE
OpenAPI json for watsonX integration guide

### DIFF
--- a/watsonx-integration/VerifyFactorsOpenAPI.json
+++ b/watsonx-integration/VerifyFactorsOpenAPI.json
@@ -1,0 +1,124 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "IBM Security Verify - Authentication Factors 2.0",
+    "version": "2.0.0",
+    "description": "Retrieve authentication factors for a user."
+  },
+  "servers": [
+    {
+      "url": "https://{tenanturl}",
+      "variables": {
+        "tenanturl": {
+          "default": "{tenant_url}",
+          "description": "Tenant base URL"
+        }
+      }
+    }
+  ],
+  "paths": {
+    "/v2.0/factors": {
+      "get": {
+        "summary": "Retrieve authentication factors for a user",
+        "operationId": "getAuthenticationFactorsForUser",
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "required": true,
+            "description": "Search criteria to filter authentication factors.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "description": "Expected response content type.",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "description": "Bearer or Basic authorization header value.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of authentication factors retrieved successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FactorsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "FactorsResponse": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "example": 1
+          },
+          "count": {
+            "type": "integer",
+            "example": 10
+          },
+          "limit": {
+            "type": "integer",
+            "example": 50
+          },
+          "total": {
+            "type": "integer",
+            "example": 100
+          },
+          "factors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Factor"
+            }
+          }
+        }
+      },
+      "Factor": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "created": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "subType": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/watsonx-integration/authenticatorVerificationOpenAPI.json
+++ b/watsonx-integration/authenticatorVerificationOpenAPI.json
@@ -1,204 +1,270 @@
 {
-  "openapi": "3.0.3",
-  "info": {
-    "title": "IBM Security Verify - Authenticator Verification API",
-    "version": "1.0.0",
-    "description": "APIs to create verification requests and get verification status."
-  },
-  "servers": [
-    {
-      "url": "https://{tenanturl}",
-      "variables": {
-        "tenanturl": {
-          "default": "{tenant_url}",
-          "description": "Tenant base URL"
-        }
-      }
-    }
-  ],
-  "paths": {
-    "/v1.0/authenticators/{authenticatorId}/verifications": {
-      "post": {
-        "summary": "Create a verification request",
-        "operationId": "createVerificationRequest",
-        "parameters": [
-          {
-            "name": "authenticatorId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique ID of the authenticator."
-          },
-          {
-            "name": "Accept",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "default": "application/json"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "Content-Type",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "default": "application/json"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Verification request created successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VerificationResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1.0/authenticators/{authenticatorId}/verifications/{verificationId}": {
-      "get": {
-        "summary": "Get verification status",
-        "operationId": "getVerificationStatus",
-        "parameters": [
-          {
-            "name": "authenticatorId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique ID of the authenticator."
-          },
-          {
-            "name": "verificationId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique ID of the verification request."
-          },
-          {
-            "name": "Accept",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "default": "application/json"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "Content-Type",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "default": "application/json"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Verification status retrieved successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VerificationStatusResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "VerificationResponse": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string"
-          },
-          "creationTime": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      },
-      "VerificationStatusResponse": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "topic": {
-            "type": "string"
-          },
-          "owner": {
-            "type": "string"
-          },
-          "state": {
-            "type": "string"
-          },
-          "expiryTime": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "userActions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/UserAction"
-            }
-          },
-          "creationTime": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      },
-      "UserAction": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "signedData": {
-            "type": "string"
-          },
-          "userAction": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  }
+	"openapi": "3.0.3",
+	"info": {
+		"title": "IBM Security Verify - Authenticator Verification API",
+		"version": "1.0.0",
+		"description": "APIs to create verification requests and get verification status."
+	},
+	"servers": [
+		{
+			"url": "https://{tenanturl}",
+			"variables": {
+				"tenanturl": {
+					"default": "{tenant_url}",
+					"description": "Tenant base URL"
+				}
+			}
+		}
+	],
+	"paths": {
+		"/v1.0/authenticators/{authenticatorId}/verifications": {
+			"post": {
+				"summary": "Create verification request",
+				"operationId": "createVerificationRequest",
+				"parameters": [
+					{
+						"name": "authenticatorId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						},
+						"description": "Unique ID of the authenticator."
+					},
+					{
+						"name": "Accept",
+						"in": "header",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"default": "application/json"
+						}
+					},
+					{
+						"name": "Authorization",
+						"in": "header",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "Content-Type",
+						"in": "header",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"default": "application/json"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/VerificationBody"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "Verification request created successfully.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/VerificationResponse"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/v1.0/authenticators/{authenticatorId}/verifications/{verificationId}": {
+			"get": {
+				"summary": "Get verification status",
+				"operationId": "getVerificationStatus",
+				"parameters": [
+					{
+						"name": "authenticatorId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						},
+						"description": "Unique ID of the authenticator."
+					},
+					{
+						"name": "verificationId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						},
+						"description": "Unique ID of the verification request."
+					},
+					{
+						"name": "Accept",
+						"in": "header",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"default": "application/json"
+						}
+					},
+					{
+						"name": "Authorization",
+						"in": "header",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "Content-Type",
+						"in": "header",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"default": "application/json"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Verification status retrieved successfully.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/VerificationStatusResponse"
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	},
+	"components": {
+		"schemas": {
+			"VerificationBody": {
+				"type": "object",
+				"properties": {
+					"transactionData": {
+						"type": "object",
+						"properties": {
+							"message": {
+								"type": "string"
+							},
+							"originIpAddress": {
+								"type": "string",
+								"default": "192.168.222.222"
+							},
+							"originUserAgent": {
+								"type": "string",
+								"default": "watsonx orchestrate"
+							}
+						}
+					},
+					"pushNotification": {
+						"type": "object",
+						"properties": {
+							"send": {
+								"type": "boolean",
+								"default": true
+							},
+							"message": {
+								"type": "string"
+							},
+							"title": {
+								"type": "string",
+								"default": "Trade App"
+							}
+						}
+					},
+					"authenticationMethods": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"default": [
+								{
+									"methodType": "signature",
+									"id": "XXXXXXXXXXXXXXXXX"
+								}
+							]
+						}
+					},
+					"logic": {
+						"type": "string",
+						"default": "OR"
+					},
+					"expiresIn": {
+						"type": "integer",
+						"default": 120
+					}
+				}
+			},
+			"VerificationResponse": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "string"
+					},
+					"status": {
+						"type": "string"
+					},
+					"creationTime": {
+						"type": "string",
+						"format": "date-time"
+					}
+				}
+			},
+			"VerificationStatusResponse": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "string"
+					},
+					"topic": {
+						"type": "string"
+					},
+					"owner": {
+						"type": "string"
+					},
+					"state": {
+						"type": "string"
+					},
+					"expiryTime": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"userActions": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/UserAction"
+						}
+					},
+					"creationTime": {
+						"type": "string",
+						"format": "date-time"
+					}
+				}
+			},
+			"UserAction": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "string"
+					},
+					"signedData": {
+						"type": "string"
+					},
+					"userAction": {
+						"type": "string"
+					}
+				}
+			}
+		}
+	}
 }

--- a/watsonx-integration/authenticatorVerificationOpenAPI.json
+++ b/watsonx-integration/authenticatorVerificationOpenAPI.json
@@ -1,0 +1,204 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "IBM Security Verify - Authenticator Verification API",
+    "version": "1.0.0",
+    "description": "APIs to create verification requests and get verification status."
+  },
+  "servers": [
+    {
+      "url": "https://{tenanturl}",
+      "variables": {
+        "tenanturl": {
+          "default": "{tenant_url}",
+          "description": "Tenant base URL"
+        }
+      }
+    }
+  ],
+  "paths": {
+    "/v1.0/authenticators/{authenticatorId}/verifications": {
+      "post": {
+        "summary": "Create a verification request",
+        "operationId": "createVerificationRequest",
+        "parameters": [
+          {
+            "name": "authenticatorId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique ID of the authenticator."
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Verification request created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VerificationResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1.0/authenticators/{authenticatorId}/verifications/{verificationId}": {
+      "get": {
+        "summary": "Get verification status",
+        "operationId": "getVerificationStatus",
+        "parameters": [
+          {
+            "name": "authenticatorId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique ID of the authenticator."
+          },
+          {
+            "name": "verificationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique ID of the verification request."
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Verification status retrieved successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VerificationStatusResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "VerificationResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "creationTime": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "VerificationStatusResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "topic": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "expiryTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "userActions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserAction"
+            }
+          },
+          "creationTime": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "UserAction": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "signedData": {
+            "type": "string"
+          },
+          "userAction": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/watsonx-integration/oauth2IntrospectOpenAPI.json
+++ b/watsonx-integration/oauth2IntrospectOpenAPI.json
@@ -1,0 +1,84 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "IBM Security Verify - OAuth2 Introspect Token",
+    "version": "2.0.0",
+    "description": "Introspect OAuth2 token and return token details."
+  },
+  "servers": [
+    {
+      "url": "https://{tenanturl}",
+      "variables": {
+        "tenanturl": {
+          "default": "{tenant_url}",
+          "description": "Tenant base URL"
+        }
+      }
+    }
+  ],
+  "paths": {
+    "/oauth2/introspect": {
+      "post": {
+        "summary": "Introspect OAuth2 Token",
+        "operationId": "introspectOAuth2Token",
+        "responses": {
+          "200": {
+            "description": "Token introspection successful.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntrospectResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "IntrospectResponse": {
+        "type": "object",
+        "properties": {
+          "aud": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "exp": {
+            "type": "integer"
+          },
+          "iat": {
+            "type": "integer"
+          },
+          "iss": {
+            "type": "string"
+          },
+          "sub": {
+            "type": "string"
+          },
+          "nbf": {
+            "type": "integer"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "grant_id": {
+            "type": "string"
+          },
+          "userType": {
+            "type": "string"
+          },
+          "client_id": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/watsonx-integration/oauth2TokenOpenAPI.json
+++ b/watsonx-integration/oauth2TokenOpenAPI.json
@@ -1,0 +1,72 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "IBM Security Verify - OAuth2 Token Exchange",
+    "version": "2.0.0",
+    "description": "Exchange token for access token with authorization details."
+  },
+  "servers": [
+    {
+      "url": "https://{tenanturl}",
+      "variables": {
+        "tenanturl": {
+          "default": "{tenant_url}",
+          "description": "Tenant base URL"
+        }
+      }
+    }
+  ],
+  "paths": {
+    "/oauth2/token": {
+      "post": {
+        "summary": "Exchange token for access token with authorization details",
+        "operationId": "exchangeTokenForAccessToken",
+        "responses": {
+          "200": {
+            "description": "Access token successfully exchanged.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "TokenResponse": {
+        "type": "object",
+        "properties": {
+          "scope": {
+            "type": "string"
+          },
+          "grant_id": {
+            "type": "string"
+          },
+          "expires_in": {
+            "type": "integer"
+          },
+          "token_type": {
+            "type": "string"
+          },
+          "access_token": {
+            "type": "string"
+          },
+          "refresh_token": {
+            "type": "string"
+          },
+          "allowedFactors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Overview**
This pull request adds OpenAPI json files required for configuring orchestration in WatsonX orchestrator.

What's Included
New directory: /verify-saas-resoiurces/watsonx-integration
JSON files:
oauth2TokenOpenAPI.json
authenticatorVerificationOpenAPI.json
VerifyFactorsOpenAPI.json
oauth2IntrospectOpenAPI.json

Why These Changes?
The files are required to import in WatsonX orchestrator to create Verify API definition. Integration guide will be created at docs.verify.ibm.com and user will be asked to download the required files from this location.

Validation
All JSON files pass linting/syntax checks
